### PR TITLE
Fix gem dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     activesupport (3.0.0)
       activesupport (= 3.0.0)
-    json (1.8.0)
+    json (1.8.3)
     rack (1.5.2)
     rack-cache (1.2)
       rack (>= 0.4)


### PR DESCRIPTION
## What does this PR do?
It fixes the installation process. With ruby 2.2 `bundle install` will fail. Since `json 1.8.0` gem cannot be installed with ruby 2.2
see the following issue and PR: https://github.com/flori/json/issues/229
json 1.8.2 fixes the problem.