### PR TITLE
Foreman needs to be installed before you can use it

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ For developers - local setup
 
 This is a fairly bog-standard sinatra app.  Clone the respository, bundle install.
 
+Install foreman with `gem install foreman`.
+
 For it to work locally, you'll need to generate some keys from the Google API Console (and turn on the Google Analytics API).  You can use @migurski's OAuth dance app to get those values: [OAuth Dance](http://oauth-dance.herokuapp.com/)
 
 You also need the View ID from the Google Analytics account you're accessing (look in Admin > View Settings > View ID).


### PR DESCRIPTION
## What does this PR do?

The Readme states that you can use foreman to run it locally. But you need to install the foreman gem before you can use it unless you have it already installed. But most non-ruby folks might not have it installed.