### PR TITLE
Historic Endpoint fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     activesupport (3.0.0)
       activesupport (= 3.0.0)
-    json (1.8.0)
+    json (1.8.3)
     rack (1.5.2)
     rack-cache (1.2)
       rack (>= 0.4)

--- a/public/javascripts/traffic.js
+++ b/public/javascripts/traffic.js
@@ -7,13 +7,12 @@
     return (Math.random() * debugCountLimit) | 0;
   };
 
-  var today = new Date().toISOString();
-    today = today.split("T"[0]);
-  
-  var yesterday = new Date();
-  yesterday.setDate(yesterday.getDate() - 1);
-  yesterday = yesterday.toISOString();
-  yesterday = yesterday.split("T"[0]);
+  var dateFormat = d3.time.format("%Y-%m-%d");
+  var todayDate = new Date();
+  var today = dateFormat(todayDate);
+
+  var yesterdayDate = d3.time.day.offset(new Date(), -1);
+  var yesterday = dateFormat(yesterdayDate);
 
   if(typeof root.matrix === 'undefined'){ root.matrix = {} }
 
@@ -32,7 +31,7 @@
       return "/realtime?ids=ga:"+matrix.settings.profileId+"&metrics=rt:activeUsers&max-results=10"
     },
     historic: function(){
-      return "/historic?ids=ga:"+matrix.settings.profileId+"&dimensions=ga%3AnthMinute&metrics=ga%3Asessions&start-date="+yesterday[0]+"&end-date="+today[0]+"&max-results=1000"
+      return "/historic?ids=ga:"+matrix.settings.profileId+"&dimensions=ga%3AnthMinute&metrics=ga%3Asessions&start-date="+yesterday+"&end-date="+today+"&max-results=1000"
     },
     parseResponse: function(data){
 


### PR DESCRIPTION
## What does this PR do?

It changes the way the dates for the `historic` endpoint gets created. 
#### Date creation
Previously they were created with the js `date` function. 
But the function has it's limitation, especially if you subtract a number form the date. 
The day before Aug. 1 will not be July 31st. 
Since we're using d3 anyway, I opted to use d3 to create the day before today with `d3.time.day.offset`

#### Date format
The date format was created by splitting up the ISO string. But d3 has a neat method available: `d3.time.format` which makes it much more easier to reuse.

Depends on #45 

