### PR TITLE
Add Test framework

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,1 +1,2 @@
 service_name: travis-ci
+repo_token: xEar0pUfRRkhLz28r7gzCO7rv9KXgH7Np

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .sass-cache
 startup.sh
 .env
+node_modules/
+coverage/
+*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "0.10"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ Then, once you've added that file, you can simply run
 
 and view the project at localhost:5000
 
+Testing
+-----------
+
+This project uses [karma](http://karma-runner.github.io/) to run the tests.
+Install node and npm to run the tests.
+
+Install the dependencies with
+```
+npm install
+```
+
+To run the tests:
+```
+karma start
+```
+
 Contributing
 ------------
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,33 @@
+module.exports = function(config) {
+  config.set({
+    basePath: '',
+    frameworks: ['mocha', 'chai-jquery', 'jquery-2.1.0', 'chai', 'sinon-chai', 'fixture'],
+    files: [
+      'public/javascripts/vendor/d3.v3.min.js',
+      'tests/**/*Spec.js',
+      'tests/fixtures/**/*'
+    ],
+    exclude: [
+      '**/*.swp'
+    ],
+    preprocessors: {
+      'tests/**/*.json'   : ['json_fixtures']
+    },
+    jsonFixturesPreprocessor: {
+      variableName: '__json__'
+    },
+    reporters: ['progress', 'coverage'],
+    coverageReporter: {
+      reporters: [
+        { type: 'html', subdir: 'report-html' },
+        { type: 'lcov', subdir: 'lcov-report' },
+      ],
+    },
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['PhantomJS'],
+    singleRun: false
+  });
+};

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,6 +12,7 @@ module.exports = function(config) {
       '**/*.swp'
     ],
     preprocessors: {
+      'public/javascripts/*.js': ['coverage'],
       'tests/**/*.json'   : ['json_fixtures']
     },
     jsonFixturesPreprocessor: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,6 +4,7 @@ module.exports = function(config) {
     frameworks: ['mocha', 'chai-jquery', 'jquery-2.1.0', 'chai', 'sinon-chai', 'fixture'],
     files: [
       'public/javascripts/vendor/d3.v3.min.js',
+      'public/javascripts/traffic.js',
       'tests/**/*Spec.js',
       'tests/fixtures/**/*'
     ],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "city-analytics-dashboard",
+  "version": "0.2.0",
+  "description": "This is a display screen to show real time analytics of a given website.",
+  "main": "index.js",
+  "scripts": {
+    "test": "./node_modules/karma/bin/karma start --single-run --browsers PhantomJS"
+  },
+  "devDependencies": {
+    "karma": "^0.13.2",
+    "karma-chai": "0.1.0",
+    "karma-chai-jquery": "^1.0.0",
+    "karma-coverage": "^0.4.2",
+    "karma-fixture": "^0.2.5",
+    "karma-jquery": "^0.1.0",
+    "karma-json-fixtures-preprocessor": "0.0.4",
+    "karma-mocha": "^0.1.10",
+    "karma-phantomjs-launcher": "0.1.4",
+    "karma-sinon-chai": "0.3.0",
+    "mocha": "^2.2.5"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/milafrerichs/city-analytics-dashboard.git"
+  },
+  "author": "Mila Frerichs",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/milafrerichs/city-analytics-dashboard/issues"
+  },
+  "homepage": "https://github.com/milafrerichs/city-analytics-dashboard"
+}

--- a/tests/trafficSpec.js
+++ b/tests/trafficSpec.js
@@ -14,4 +14,19 @@ describe('traffic', function() {
   it('has interval of 2 minutes', function() {
     expect(subject.interval).to.eq(120000);
   });
+  describe('#endpoint', function() {
+    it('returns the path to the servers realtime endpoint', function() {
+      expect(subject.endpoint()).to.eql('/realtime?ids=ga:&metrics=rt:activeUsers&max-results=10');
+    });
+    context('with profileId', function() {
+      beforeEach(function() {
+        window.matrix.settings = {
+          profileId: 'Test'
+        };
+      });
+      it('returns correct profile Id in the endpoint path', function() {
+        expect(subject.endpoint()).to.eql('/realtime?ids=ga:Test&metrics=rt:activeUsers&max-results=10');
+      });
+    });
+  });
 });

--- a/tests/trafficSpec.js
+++ b/tests/trafficSpec.js
@@ -40,4 +40,20 @@ describe('traffic', function() {
       expect(subject.historic()).to.eql('/historic?ids=ga:&dimensions=ga%3AnthMinute&metrics=ga%3Asessions&start-date=2015-08-03&end-date=2015-08-04&max-results=1000');
     });
   });
+  describe('#init', function() {
+    it('sets the count to the points value', function() {
+      subject.init();
+      expect(subject.counts.length).to.eq(subject.points);
+    });
+    it('fills the counts with zeros', function() {
+      subject.points = 1;
+      subject.init();
+      expect(subject.counts[0]).to.eq(0);
+    });
+    it('calls the historic endpoint', function() {
+      mock = sandbox.mock(subject).expects('historic').returns('');
+      subject.init();
+      mock.verify();
+    });
+  });
 });

--- a/tests/trafficSpec.js
+++ b/tests/trafficSpec.js
@@ -55,5 +55,33 @@ describe('traffic', function() {
       subject.init();
       mock.verify();
     });
+    context('no json returned', function() {
+      beforeEach(function() {
+        stub = sandbox.stub(d3, 'json');
+      });
+      it('returns without reloading', function() {
+        mock = sandbox.mock(subject).expects('reload').never();
+        subject.init();
+        stub.callArgWith(1, {}, null)
+        mock.verify();
+      });
+    });
+    context('returns json', function() {
+      beforeEach(function() {
+        stub = sandbox.stub(d3, 'json');
+        subject.points = 1;
+      });
+      it('set the count to row value', function() {
+        subject.init();
+        stub.callArgWith(1, null, {rows: [["000000",1],["000001",1]]});
+        expect(subject.counts[0]).to.eql(1);
+      });
+      it('reloads', function() {
+        mock = sandbox.mock(subject).expects('reload').once();
+        subject.init();
+        stub.callArgWith(1, null, {rows: [["000000",1],["000001",1]]});
+        mock.verify();
+      });
+    });
   });
 });

--- a/tests/trafficSpec.js
+++ b/tests/trafficSpec.js
@@ -29,4 +29,9 @@ describe('traffic', function() {
       });
     });
   });
+  describe('#historic', function() {
+    it('returns the path to the servers historic endpoint', function() {
+      expect(subject.historic()).to.eql('/historic?ids=ga:&dimensions=ga%3AnthMinute&metrics=ga%3Asessions&start-date=2015-08-03&end-date=2015-08-04&max-results=1000');
+    });
+  });
 });

--- a/tests/trafficSpec.js
+++ b/tests/trafficSpec.js
@@ -1,0 +1,17 @@
+describe('traffic', function() {
+  beforeEach(function() {
+    window.matrix.settings = {
+      profileId: ''
+    };
+    subject =  window.matrix.traffic;
+  });
+  it('has initial points', function() {
+    expect(subject.points).to.eq(720);
+  });
+  it('has empty counts', function() {
+    expect(subject.counts).to.eql([]);
+  });
+  it('has interval of 2 minutes', function() {
+    expect(subject.interval).to.eq(120000);
+  });
+});

--- a/tests/trafficSpec.js
+++ b/tests/trafficSpec.js
@@ -4,6 +4,12 @@ describe('traffic', function() {
       profileId: ''
     };
     subject =  window.matrix.traffic;
+    sandbox = sinon.sandbox.create();
+    server = sinon.fakeServer.create();
+  });
+  afterEach(function() {
+    sandbox.restore();
+    server.restore();
   });
   it('has initial points', function() {
     expect(subject.points).to.eq(720);


### PR DESCRIPTION
## What does this PR do?

It adds the _karma_ test framework. It's very good and easy for headless js testing. 
I use _Phantom_JS_ to test in the console and use TDD and continuous testing to get instant feedback.

### Installation
Install dependencies with  `npm install` Install karma CLI with `npm install -g karma-cli`

Run tests with 
`karma start`

### Tests
Add first Tests for `traffic.js`