### PR TITLE
Add colors to the mobile desktop usage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18,13 +18,16 @@
             </div>
             <div id="graph-text">visitors over the last 48 hours (30 minute interval)</div>
           </div>
-          <span id="traffic" class="count" style="float:left">
-            <span class="text-feature" id="traffic-count-mobile">&nbsp;</span>
-            mobile
-            <span class="text-feature" id="traffic-count">&nbsp;</span>
-            desktop
-            <br/>
-            visitors online
+          <span id="traffic" class="count">
+            <div class="visitor-count" id="mobile-count">
+              <span class="text-feature" id="traffic-count-mobile">&nbsp;</span>
+              mobile
+            </div>
+            <div class="visitor-count" id="desktop-count">
+              <span class="text-feature" id="traffic-count">&nbsp;</span>
+              desktop
+            </div>
+            <span>visitors online</span>
           </span>
         </div>
 

--- a/public/stylesheets/base.css
+++ b/public/stylesheets/base.css
@@ -197,6 +197,17 @@ h2 {
   .traffic .label {
     fill: #78BFBF;
     font-size: 16px; }
+  .traffic #traffic {
+    float: left; }
+    .traffic #traffic .visitor-count {
+      width: 90px;
+      height: 90px;
+      margin: 0 auto; }
+      .traffic #traffic .visitor-count#mobile-count {
+        background: #265c8d; }
+      .traffic #traffic .visitor-count#desktop-count {
+        background: #1b406d;
+        margin-bottom: 5px; }
 
 .sparkline path {
   stroke: white;

--- a/public/stylesheets/base.scss
+++ b/public/stylesheets/base.scss
@@ -22,6 +22,8 @@ mid teal: 78BFBF
 teal: 60BFB6
 */
 
+$desktop-color: #1b406d;
+$mobile-color: #265c8d;
 
 html {
   width: 100%;
@@ -253,6 +255,21 @@ h2{
   .label {
     fill: $secondary;
     font-size: 16px;
+  }
+  #traffic {
+    float: left;
+    .visitor-count {
+      width: 90px;
+      height: 90px;
+      margin: 0 auto;
+      &#mobile-count{
+        background: $mobile-color;
+      }
+      &#desktop-count{
+        background: $desktop-color;
+        margin-bottom: 5px;
+      }
+    }
   }
 }
 .sparkline path{


### PR DESCRIPTION
## What does this PR do?

It adds the colors for the mobile and desktop usage to the current active users

## Screenshot
![bildschirmfoto 2015-08-26 um 17 02 33](https://cloud.githubusercontent.com/assets/688980/9497249/6b6b3fc0-4c14-11e5-93fb-4715c476a254.png)

## Related Issues
#43 