### PR TITLE
Event Listener for IE<9

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -78,7 +78,7 @@
         titlefilter: ' ~ '
       };
 
-      window.addEventListener("load", matrix.manager.init);
+      addEvent("load", window, matrix.manager.init);
     </script>
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,7 @@
     <link href='http://fonts.googleapis.com/css?family=Bitter:400,700,400italic' rel='stylesheet' type='text/css' />
     <meta name="viewport"
      content="width=device-width, minimum-scale=1.0,initial-scale=1.0, user-scalable=yes" />
+     <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   </head>
   <body>
     <div class="top-bar">

--- a/public/javascripts/manager.js
+++ b/public/javascripts/manager.js
@@ -118,6 +118,16 @@
     window.requestAnimationFrame(_animateDownBy);
   };
 
+  root.addEvent = function(evnt, elem, myfunc) {
+    if (elem.addEventListener){
+        elem.addEventListener(evnt, myfunc);
+    } else if (elem.attachEvent){
+       elem.attachEvent("on"+ev, myfunc);
+    } else {
+      elem["on"+evnt] = myfunc;
+    }
+  }
+
   var manager =
   root.matrix.manager = {
     animationDuration: 500,


### PR DESCRIPTION
## What does this PR do?

IE < 9 do not support `addEventLister` but instead use `attachEvent` (http://www.mediaevent.de/javascript/event_listener.html)
This PR provides a method to initialize the dashboard regardless of the support of `addEventListener`
