### PR TITLE
Remove deviceClass icon from active pages and search

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -127,7 +127,6 @@
       <li>
         <div class="device-type {{deviceCategory}}"></div>
         <div class="link">
-          <i class="{{deviceClass deviceCategory}}"></i>
           <a href="http://{{ url }}" target="_blank">{{ term }}</a>
         </div>
       </li>
@@ -137,7 +136,6 @@
       <li>
         <div class="device-type {{deviceCategory}}"></div>
         <div>
-          <i class="{{deviceClass deviceCategory}}"></i>
           <a href="http://{{ url }}" target="_blank">{{ term }}</a>
         </div>
       </li>
@@ -148,7 +146,6 @@
       <li>
         <div class="device-type {{deviceCategory}}"></div>
         <div class="link">
-          <i class="{{deviceClass deviceCategory}}"></i>
           {{#has_url}}<a href="http://{{ url }}" target="_blank">{{/has_url}}
           {{ term }}
           {{#has_url}}</a>{{/has_url}}


### PR DESCRIPTION
## What does this PR do?

It removes the icons for mobile and desktop from the active pages and search tab. 