### PR TITLE
"Dribble" out the results for active pages

### DIFF
--- a/public/javascripts/landing-pages.js
+++ b/public/javascripts/landing-pages.js
@@ -78,7 +78,24 @@
       }
     },
     refreshResults: function() {
-      templateHelper.prependTemplate(landing.el, "landing-pages-items", {pages: landing.terms });
+      landing.dribbleOut(landing.terms);
+    },
+    dribbleOut: function(data) {
+      var i, dataLength = data.length;
+      for(i=0;i<dataLength;i++) {
+        var term = data[i];
+        var smallValueAdjustment = 1;
+        //if(dataLength < 15) { smallValueAdjustment = dataLength*2; }
+        var timeOut = 60/dataLength*i*1000/smallValueAdjustment;
+        setTimeout((function(term) {
+          return function() {
+            landing.showTerm(term);
+          };
+        })(term), timeOut);
+      }
+    },
+    showTerm: function(term) {
+      templateHelper.prependTemplate(landing.el, "landing-pages-items", {pages: [term ]});
     },
     init: function(){
       var source;

--- a/public/javascripts/landing-pages.js
+++ b/public/javascripts/landing-pages.js
@@ -78,15 +78,13 @@
       }
     },
     refreshResults: function() {
-      landing.dribbleOut(landing.terms);
+      landing.showOneByOne(landing.terms);
     },
-    dribbleOut: function(data) {
+    showOneByOne: function(data) {
       var i, dataLength = data.length;
       for(i=0;i<dataLength;i++) {
         var term = data[i];
-        var smallValueAdjustment = 1;
-        //if(dataLength < 15) { smallValueAdjustment = dataLength*2; }
-        var timeOut = 60/dataLength*i*1000/smallValueAdjustment;
+        var timeOut = 60/dataLength*i*1000;
         setTimeout((function(term) {
           return function() {
             landing.showTerm(term);

--- a/tests/landingPagesSpec.js
+++ b/tests/landingPagesSpec.js
@@ -136,7 +136,7 @@ describe('traffic', function() {
       mock.verify();
     });
   });
-  describe('#dribbleOut', function() {
+  describe('#showOneByOne', function() {
     beforeEach(function() {
       term = { term: 'Test', total: 1, url: 'url', source: 'source' };
       subject.terms = [];
@@ -148,7 +148,7 @@ describe('traffic', function() {
       });
       it("adds an element every second", function() {
         mock.exactly(60);
-        subject.dribbleOut(subject.terms);
+        subject.showOneByOne(subject.terms);
         clock.tick(60000);
         mock.verify();
       });
@@ -159,7 +159,7 @@ describe('traffic', function() {
       });
       it("adds an element every two seconds", function() {
         mock.exactly(30);
-        subject.dribbleOut(subject.terms);
+        subject.showOneByOne(subject.terms);
         clock.tick(60000);
         mock.verify();
       });

--- a/tests/landingPagesSpec.js
+++ b/tests/landingPagesSpec.js
@@ -6,10 +6,12 @@ describe('traffic', function() {
     subject =  window.matrix.landing;
     sandbox = sinon.sandbox.create();
     server = sinon.fakeServer.create();
+    clock = sinon.useFakeTimers();
   });
   afterEach(function() {
     sandbox.restore();
     server.restore();
+    clock.restore();
   });
   describe('#init', function() {
     beforeEach(function() {
@@ -130,7 +132,37 @@ describe('traffic', function() {
     it("calls handlebars template", function() {
       mock = sandbox.mock(templateHelper).expects('prependTemplate').once();
       subject.refreshResults();
+      clock.tick(1);
       mock.verify();
+    });
+  });
+  describe('#dribbleOut', function() {
+    beforeEach(function() {
+      term = { term: 'Test', total: 1, url: 'url', source: 'source' };
+      subject.terms = [];
+      mock = sandbox.mock(templateHelper).expects('prependTemplate');
+    });
+    context("60 elements", function() {
+      beforeEach(function() {
+        for(var i=0;i<60;i++) { subject.terms.push(term); }
+      });
+      it("adds an element every second", function() {
+        mock.exactly(60);
+        subject.dribbleOut(subject.terms);
+        clock.tick(60000);
+        mock.verify();
+      });
+    });
+    context("30 elements", function() {
+      beforeEach(function() {
+        for(var i=0;i<30;i++) { subject.terms.push(term); }
+      });
+      it("adds an element every two seconds", function() {
+        mock.exactly(30);
+        subject.dribbleOut(subject.terms);
+        clock.tick(60000);
+        mock.verify();
+      });
     });
   });
   describe('#endpoint', function() {


### PR DESCRIPTION
## What does this PR do?
Changes the appearance for the "active pages".
Do not show all new active pages at once but show "one by one" every few seconds. 
The refresh interval for the API is for now 60 seconds. 
This PR tries to show a new page every few seconds. 
For example if there are more than 60 active pages show ever page in less than a
second (every minute new results will come in), if there are less than
60 show every other second (depending on the size of the pages)