### PR TITLE
Remove key lines as they behaive differently in every browser

### DIFF
--- a/public/stylesheets/base.css
+++ b/public/stylesheets/base.css
@@ -68,7 +68,6 @@ h2 {
     min-height: 100%;
     background-color: #00010D;
     border-radius: 3px;
-    border: 1px solid #4B9990;
     overflow: hidden; }
     .bricks .brick h2, .bricks .brick div.box {
       padding: 0 16px; }
@@ -141,7 +140,6 @@ h2 {
 .top-bar {
   background: #00010D;
   padding: 10px 20px;
-  border: 1px solid #4B9990;
   border-radius: 3px;
   color: #000;
   clear: both;

--- a/public/stylesheets/base.scss
+++ b/public/stylesheets/base.scss
@@ -73,7 +73,6 @@ h2{
     min-height: 100%;
     background-color: $secondary-background;
     border-radius: 3px;
-    border: 1px solid $background;
     overflow: hidden;
 
     h2, div.box {
@@ -171,7 +170,6 @@ h2{
 .top-bar {
   background: $secondary-background;
   padding: 10px 20px;
-  border:1px solid $background;
   border-radius: 3px;
   color:#000;
   clear:both; 


### PR DESCRIPTION
## What does this PR do?

It removes the "key lines" from the layout. 
Due to the flex grid layout the key lines do not display properly in
every browser

## Screenshot 
![bildschirmfoto 2015-09-03 um 09 52 56](https://cloud.githubusercontent.com/assets/688980/9658528/6b12b0b2-524a-11e5-908a-221115b40562.png)
